### PR TITLE
Add full API support

### DIFF
--- a/src/Firestore.elm
+++ b/src/Firestore.elm
@@ -276,7 +276,7 @@ patch fieldDecoder { updateFields, deleteFields } (Firestore config path) =
 delete : Firestore -> Task.Task Error ()
 delete (Firestore config path) =
     Http.task
-        { method = "GET"
+        { method = "DELETE"
         , headers = Config.httpHeader config
         , url = Config.endpoint [] path config
         , body = Http.emptyBody
@@ -290,7 +290,7 @@ delete (Firestore config path) =
 deleteExisting : Firestore -> Task.Task Error ()
 deleteExisting (Firestore config path) =
     Http.task
-        { method = "GET"
+        { method = "DELETE"
         , headers = Config.httpHeader config
         , url = Config.endpoint [ UrlBuilder.string "currentDocument.exists" "true" ] path config
         , body = Http.emptyBody


### PR DESCRIPTION
As discussed in #19 a full support of the [Firestore REST API](https://firebase.google.com/docs/firestore/reference/rest/#rest-resource:-v1beta1.projects.databases.documents) would be nice to have.

That said, this is just a first draft, including all functions that we have discussed in #19.

I will keep updating the branch with additional functions.

## Checklist
* [x] `batchGet` - Skipped. Part of Transactions.
* [x] `batchWrite` - Skipped. Part of Transactions.
* [x] `beginTransaction` - Skipped. Part of Transactions.
* [x] `commit` - Skipped. Part of Transactions.
* [x] `createDocument` - Implemented as `insert` and `create`. Ignored the `mask` parameter.
* [x] `delete` - Implemented as `delete`. Ignored the `currentDocument` parameter.
* [x] `get` - Implemented as `get`. Ignored the `mask` and `consistency_selector` parameters.
* [x] `list` - Implemented as `list`. Ignored the `mask`, `showMissing` and `consistency_selector` parameters.
* [x] `listCollectionIds` - Skipped. Could not figure out how to use it
* [x] `partitionQuery` - Skipped. Too compilcated for now
* [x] `patch` - Implemented as `patch`. Ignored the `currentDocument` parameters
* [x] `rollback` - Skipped. Part of Transactions.
* [x] `runQuery` - Skipped. Too compilcated for now